### PR TITLE
User Tile: Improved UI

### DIFF
--- a/views/nav.pug
+++ b/views/nav.pug
@@ -10,7 +10,7 @@
 mixin userTile(username, displayName, link, linkTitle, actionLink, action)
   if username
     a.btn.btn-sm.btn-muted(href=link, target='_new', title=linkTitle)= username
-  if displayName
+  if displayName && displayName !== username
     a.btn.btn-sm.btn-muted-more(href=link, target='_new', title=linkTitle)= displayName
   if action
     a.btn.btn-sm.btn-white(href=actionLink, style='margin-left:10px')= action


### PR DESCRIPTION
No longer duplicating username and displayName when present.
Since a GitHub session may not be present, and we do not typically
store the GitHub display name, it will fall back to username. No
need really for us to do that in the UI.