### PR TITLE
Moving to the latest passport-azure-ad

### DIFF
--- a/middleware/passport-config.js
+++ b/middleware/passport-config.js
@@ -76,7 +76,7 @@ module.exports = function (app, config) {
     clientID: config.activeDirectory.clientId,
     clientSecret: config.activeDirectory.clientSecret,
     oidcIssuer: config.activeDirectory.issuer,
-    identityMetadata: 'https://login.microsoftonline.com/common/.well-known/openid-configuration',
+    identityMetadata: 'https://login.microsoftonline.com/' + config.activeDirectory.tenantId + '/.well-known/openid-configuration',
     skipUserProfile: true,
     responseType: 'id_token code',
     responseMode: 'form_post',

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "octonode": "0.7.6",
     "painless-config": "^0.1.0",
     "passport": "^0.3.2",
-    "passport-azure-ad": "^2.0.0",
+    "passport-azure-ad": "^2.0.1",
     "passport-github": "^1.1.0",
     "pug": "^2.0.0-beta4",
     "redis": "^2.6.2",


### PR DESCRIPTION
Using v2.0.1. Using the single tenant (not common) endpoint based on the realm/tenant.